### PR TITLE
feat : 가게 대표 이미지 스케줄링

### DIFF
--- a/gusto/.idea/uiDesigner.xml
+++ b/gusto/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/gusto/src/main/java/com/umc/gusto/GustoApplication.java
+++ b/gusto/src/main/java/com/umc/gusto/GustoApplication.java
@@ -3,8 +3,10 @@ package com.umc.gusto;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class GustoApplication {
 

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/response/PinByMyCategoryResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/response/PinByMyCategoryResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Builder
 @Getter
 @NoArgsConstructor
@@ -14,6 +16,6 @@ public class PinByMyCategoryResponse{
     Long storeId;
     String storeName;
     String address;
-    String reviewImg;
+    List<String> reviewImg3;
     Integer reviewCnt;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/entity/ReviewImages.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/entity/ReviewImages.java
@@ -1,0 +1,34 @@
+package com.umc.gusto.domain.review.entity;
+
+import com.umc.gusto.domain.store.entity.Store;
+import com.umc.gusto.global.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReviewImages extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reviewImagesId")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storeId")
+    private Store store;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @JoinTable(name = "reviewImgList", joinColumns = @JoinColumn(name = "reviewImgListId"))
+    private List<String> reviewImgList = new ArrayList<>();
+
+    public void updateReviewImgList(List<String> reviewImgList) {
+        this.reviewImgList = reviewImgList;
+    }
+
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewImagesRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewImagesRepository.java
@@ -1,0 +1,9 @@
+package com.umc.gusto.domain.review.repository;
+
+import com.umc.gusto.domain.review.entity.ReviewImages;
+import com.umc.gusto.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewImagesRepository extends JpaRepository<ReviewImages, Long> {
+    ReviewImages findByStore(Store store);
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -19,8 +19,8 @@ import java.util.UUID;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.liked DESC LIMIT 1")
     Optional<Review> findFirstByStoreOrderByLikedDesc(Store store);
-    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.liked DESC, r.reviewId DESC LIMIT 3")
-    List<Review> findFirst3ByStoreOrderByLikedDesc(Store store);
+//    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.liked DESC, r.reviewId DESC LIMIT 3")
+//    List<Review> findFirst3ByStoreOrderByLikedDesc(Store store);
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.liked DESC, r.reviewId DESC LIMIT 4")
     List<Review> findFirst4ByStoreOrderByLikedDesc(Store store);
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.visitedAt DESC, r.reviewId DESC")

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewImageServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewImageServiceImpl.java
@@ -1,0 +1,48 @@
+package com.umc.gusto.domain.review.service;
+
+import com.umc.gusto.domain.review.entity.Review;
+import com.umc.gusto.domain.review.entity.ReviewImages;
+import com.umc.gusto.domain.review.repository.ReviewImagesRepository;
+import com.umc.gusto.domain.review.repository.ReviewRepository;
+import com.umc.gusto.domain.store.entity.Store;
+import com.umc.gusto.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewImageServiceImpl {
+    private final StoreRepository storeRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewImagesRepository reviewImagesRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * MON")
+    public void updateStoreReviewImages() {
+        List<Store> stores = storeRepository.findAll();
+
+        for (Store store : stores) {
+            List<Review> top4Reviews = reviewRepository.findFirst4ByStoreOrderByLikedDesc(store);
+            List<String> reviewImages = top4Reviews.stream()
+                    .map(Review::getImg1)
+                    .collect(Collectors.toList());
+
+            ReviewImages storeReviewImages = reviewImagesRepository.findByStore(store);
+
+            if (storeReviewImages == null) {
+                storeReviewImages = ReviewImages.builder()
+                        .store(store)
+                        .reviewImgList(reviewImages)
+                        .build();
+            } else {
+                storeReviewImages.updateReviewImgList(reviewImages);
+            }
+            reviewImagesRepository.save(storeReviewImages);
+        }
+    }
+}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 가게 대표 이미지를 스케줄링을 사용해 월요일마다 업데이트될 수 있도록 구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 가게 대표 이미지를 API를 불러올 때마다 좋아요가 많은 리뷰의 이미지를 반복해서 가져오는 것은 비효율적이라 여겨, 매주 일요일 자정마다 대표 이미지를 업데이트하기로 변경

### 작업 내역

- @Scheduled를 사용해 월요일마다 가게 대표이미지가 업데이트될 수 있도록 작업
- 스케줄링 시 4개의 이미지를 저장하고, 3개의 이미지가 필요한 경우 리스트 슬라이싱 작

### 작업 후 기대 동작(스크린샷)
- 카테고리 별 가게 목록 조회
![스크린샷 2024-05-25 174200](https://github.com/gusto-umc/Gusto-Server/assets/102590823/72d14d4a-c1ff-4aff-8d47-58fef33068c4)
- 가게 조회
![스크린샷 2024-05-25 174555](https://github.com/gusto-umc/Gusto-Server/assets/102590823/b1f51c8f-3c19-46a0-9f1e-32c8fc839300)
- 가게 상세 조회
![스크린샷 2024-05-25 174618](https://github.com/gusto-umc/Gusto-Server/assets/102590823/f620cf7e-ebf2-4e44-9e2f-f28b523e3b36)


### PR 특이 사항

- 캐시에 저장해서 엔티티에 저장하는 작업을 최소화하려고 했으나 서버 비용이 늘어날 거 같아, 엔티티를 새롭게 구현했습니다.
- 4개의 이미지를 받아되는 경우가 있어 스케줄링 시 4개의 이미지를 reviewImages 엔티티에 저장하고, 리스트 슬라이싱으로 3개의 이미지 필요한 경우는 3개의 이미지만 조회할 수 있도록 구현했습니다.