### PR TITLE
feat : 내 카테고리 개별/전체 공개 여부에 따른 수정 및 추가

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/controller/MyCategoryController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/controller/MyCategoryController.java
@@ -60,6 +60,11 @@ public class MyCategoryController {
     }
 
     /**
+     * 내 카테고리 공개 상태 업데이트
+     * [
+     */
+
+    /**
      * 내 카테고리 생성
      * [POST] /myCategories
      */

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
@@ -36,10 +36,13 @@ public class MyCategory extends BaseEntity{
     @Column(length = 20)
     private String myCategoryScript;
 
-//    @Builder.Default
-//    @Enumerated(EnumType.STRING)
-//    @Column(name = "publishCategory",nullable = false, length = 10)
-//    private PublishStatus publishCategory = PublishStatus.PUBLIC;
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "publishCategory",nullable = false, length = 10)
+    private PublishStatus publishCategory = PublishStatus.PUBLIC;
+
+    @Enumerated(EnumType.STRING)
+    private PublishStatus previousPublishCategory = PublishStatus.PUBLIC;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
@@ -61,9 +64,10 @@ public class MyCategory extends BaseEntity{
     }
 
     // 데모데이 이후 진행
-//    public void updatePublishCategory(PublishStatus publishCategory) {
-//        this.publishCategory = publishCategory;
-//    }
-
+    public void updatePublishCategory(PublishStatus publishCategory) {
+        this.publishCategory = publishCategory;
+        this.previousPublishCategory = publishCategory;     // 이전 값 저장
+    }
     public void updateStatus(BaseEntity.Status status) {this.status = status;}
+
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
@@ -41,6 +41,7 @@ public class MyCategory extends BaseEntity{
     @Column(name = "publishCategory",nullable = false, length = 10)
     private PublishStatus publishCategory = PublishStatus.PUBLIC;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     private PublishStatus previousPublishCategory = PublishStatus.PUBLIC;
 
@@ -66,6 +67,8 @@ public class MyCategory extends BaseEntity{
     // 데모데이 이후 진행
     public void updatePublishCategory(PublishStatus publishCategory) {
         this.publishCategory = publishCategory;
+    }
+    public void updatePreviousPublishCategory(PublishStatus publishCategory) {
         this.previousPublishCategory = publishCategory;     // 이전 값 저장
     }
     public void updateStatus(BaseEntity.Status status) {this.status = status;}

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
@@ -41,9 +41,8 @@ public class MyCategory extends BaseEntity{
     @Column(name = "publishCategory",nullable = false, length = 10)
     private PublishStatus publishCategory = PublishStatus.PUBLIC;
 
-    @Builder.Default
     @Enumerated(EnumType.STRING)
-    private PublishStatus previousPublishCategory = PublishStatus.PUBLIC;
+    private PublishStatus previousPublishCategory;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/request/CreateMyCategoryRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/request/CreateMyCategoryRequest.java
@@ -12,7 +12,7 @@ public class CreateMyCategoryRequest {
     @Size(max=20, message = "카테고리 설명은 20자를 초과할 수 없습니다.")
     String myCategoryScript;
     Integer myCategoryIcon;
-//    PublishStatus publishCategory;            // 데모데이 이후
+    PublishStatus publishCategory;            // 데모데이 이후
     BaseEntity.Status status = BaseEntity.Status.ACTIVE;
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/request/UpdateMyCategoryRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/request/UpdateMyCategoryRequest.java
@@ -8,6 +8,6 @@ public class UpdateMyCategoryRequest {
     String myCategoryName;
     String myCategoryScript;
     Integer myCategoryIcon;
-//    PublishStatus publishCategory = PublishStatus.PUBLIC;     // 데모데이 이후 각각 카테고리에 대해 publish 처리
+    PublishStatus publishCategory = PublishStatus.PUBLIC;     // 데모데이 이후 각각 카테고리에 대해 publish 처리
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/response/MyCategoryResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/response/MyCategoryResponse.java
@@ -12,6 +12,7 @@ public class MyCategoryResponse{
     String myCategoryName;
     String myCategoryScript;
     Integer myCategoryIcon;
+    PublishStatus userPublishCategory;
     PublishStatus publishCategory;
     Integer pinCnt;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/MyCategoryRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/MyCategoryRepository.java
@@ -11,13 +11,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MyCategoryRepository extends JpaRepository<MyCategory, Long> {
-    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.user.nickname = :nickname AND m.myCategoryId = :myCategoryId ORDER BY m.myCategoryId DESC")
+    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.publishCategory = 'PUBLIC' AND m.user.nickname = :nickname AND m.myCategoryId = :myCategoryId ORDER BY m.myCategoryId DESC")
     Optional<MyCategory> findByMyCategoryPublicIdAndUserNickname(String nickname, Long myCategoryId);
-    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.nickname = :nickname AND m.myCategoryId = :myCategoryId ORDER BY m.myCategoryId DESC")
+    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.publishCategory = 'PUBLIC' AND m.user.nickname = :nickname AND m.myCategoryId = :myCategoryId ORDER BY m.myCategoryId DESC")
     Optional<MyCategory> findByMyCategoryIdAndUserNickname(String nickname, Long myCategoryId);
-    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.user = :user ORDER BY m.myCategoryId DESC")
+    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.publishCategory = 'PUBLIC' AND m.user = :user ORDER BY m.myCategoryId DESC")
     Page<MyCategory> findByUserNicknameAndPublishCategoryPublic(User user, Pageable pageable);
-    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.user = :user AND m.myCategoryId < :myCategoryId ORDER BY m.myCategoryId DESC")
+    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.publishCategory = 'PUBLIC' AND m.user = :user AND m.myCategoryId < :myCategoryId ORDER BY m.myCategoryId DESC")
     Page<MyCategory> findByUserNicknameAndPublishCategoryPublicPaging(User user, Long myCategoryId, Pageable pageable);
     @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user = :user ORDER BY m.myCategoryId DESC")
     Page<MyCategory> findByUserNicknameAndPublishCategory(User user, Pageable pageable);
@@ -27,4 +27,5 @@ public interface MyCategoryRepository extends JpaRepository<MyCategory, Long> {
     Optional<MyCategory> findByMyCategoryNameAndUser(String myCategoryName, User user);
     @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.myCategoryId = :myCategoryId AND m.user = :user")
     Optional<MyCategory> findByUserAndMyCategoryId(User user, Long myCategoryId);
+    List<MyCategory> findByUser(User user);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
@@ -6,6 +6,7 @@ import com.umc.gusto.domain.myCategory.model.response.MyCategoryResponse;
 import com.umc.gusto.domain.myCategory.model.response.PagingResponse;
 import com.umc.gusto.domain.myCategory.model.response.PinByMyCategoryResponse;
 import com.umc.gusto.domain.user.entity.User;
+import com.umc.gusto.global.common.PublishStatus;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -18,6 +19,8 @@ public interface MyCategoryService {
     PagingResponse getAllPinByMyCategory(User user, String nickname, Long myCategoryId, String townName, Long pinId, String storeName, String sort);
 
 //    List<PinByMyCategoryResponse> getAllPinByMyCategoryWithLocation(User user, Long myCategoryId, String townName);
+
+    void savePublishCategory(User user, PublishStatus publicCategory);
 
     void createMyCategory(User user, CreateMyCategoryRequest request);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -61,15 +61,14 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                         if (townName != null) {
                             pinList = pinRepository.findPinsByMyCategoryAndTownNameAndPinIdDESC(myCategory, townName);     // 먼저 카테고리로 구분
                         } else {
-                            pinList = pinRepository.findPinsByMyCategoryAndPinIdDESC(myCategory);     // 먼저 카테고리로 구분
+                            pinList = pinRepository.findPinsByMyCategoryAndPinIdDESC(myCategory);                          // 먼저 카테고리로 구분
                         }
                         return MyCategoryResponse.builder()
                                 .myCategoryId(myCategory.getMyCategoryId())
                                 .myCategoryName(myCategory.getMyCategoryName())
                                 .myCategoryScript(myCategory.getMyCategoryScript())
                                 .myCategoryIcon(myCategory.getMyCategoryIcon())
-                                .publishCategory(myCategory.getPublishCategory())
-                                .pinCnt(pinList.size())            // pin 개수 받아오기로 변경
+                                .pinCnt(pinList.size())                                                                    // 타인의 카테고리의 경우 publish값을 볼 필요 X
                                 .build();
                     })
                     .collect(Collectors.toList());
@@ -215,7 +214,7 @@ public class MyCategoryServiceImpl implements MyCategoryService {
         userRepository.save(user);
         List<MyCategory> myCategoryList = myCategoryRepository.findByUser(user);
 
-        if (publishCategory == PublishStatus.PUBLIC) {
+        if (publishCategory.equals(PublishStatus.PUBLIC)) {
             for (MyCategory myCategory: myCategoryList) {
                 myCategory.updatePublishCategory(PublishStatus.PUBLIC);
             }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -15,6 +15,7 @@ import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.domain.user.repository.UserRepository;
 import com.umc.gusto.global.common.BaseEntity;
+import com.umc.gusto.global.common.PublishStatus;
 import com.umc.gusto.global.exception.Code;
 import com.umc.gusto.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -46,48 +47,72 @@ public class MyCategoryServiceImpl implements MyCategoryService {
             if (nickname.equals(user.getNickname())) {
                 throw new GeneralException(Code.USER_NOT_FOUND_SELF);
             }
-            user = userRepository.findByNickname(nickname)
+            user = userRepository.findByNickname(nickname)      // 타 닉네임 조회
                     .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
             if (myCategoryId != null) {
-                myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategoryPublicPaging(user, myCategoryId, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));
+                myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategoryPublicPaging(user, myCategoryId, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));     // 받아온 nickname과 User의 nickname 값이 다른 경우(쿼리문 사용)
             } else {
                 myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategoryPublic(user, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));
             }
-        } else {
+
+            List<MyCategoryResponse> result = myCategoryList.stream()
+                    .map(myCategory -> {
+                        List<Pin> pinList;
+                        if (townName != null) {
+                            pinList = pinRepository.findPinsByMyCategoryAndTownNameAndPinIdDESC(myCategory, townName);     // 먼저 카테고리로 구분
+                        } else {
+                            pinList = pinRepository.findPinsByMyCategoryAndPinIdDESC(myCategory);     // 먼저 카테고리로 구분
+                        }
+                        return MyCategoryResponse.builder()
+                                .myCategoryId(myCategory.getMyCategoryId())
+                                .myCategoryName(myCategory.getMyCategoryName())
+                                .myCategoryScript(myCategory.getMyCategoryScript())
+                                .myCategoryIcon(myCategory.getMyCategoryIcon())
+                                .publishCategory(myCategory.getPublishCategory())
+                                .pinCnt(pinList.size())            // pin 개수 받아오기로 변경
+                                .build();
+                    })
+                    .collect(Collectors.toList());
+
+            return PagingResponse.builder()
+                    .hasNext(myCategoryList.hasNext())
+                    .result(result)
+                    .build();
+
+        } else {    // 내 카테고리 조회
             if (myCategoryId != null) {
-                myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategoryPaging(user, myCategoryId, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));   // 받아온 nickname과 User의 nickname 값이 다른 경우(쿼리문 사용)
+                myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategoryPaging(user, myCategoryId, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));
             } else {
-                myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategory(user, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));   // 받아온 nickname과 User의 nickname 값이 다른 경우(쿼리문 사용)
+                myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategory(user, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));
             }
 
+            User finalUser = user;
+            List<MyCategoryResponse> result = myCategoryList.stream()
+                    .map(myCategory -> {
+                        List<Pin> pinList;
+                        if (townName != null) {
+                            pinList = pinRepository.findPinsByMyCategoryAndTownNameAndPinIdDESC(myCategory, townName);     // 먼저 카테고리로 구분
+                        } else {
+                            pinList = pinRepository.findPinsByMyCategoryAndPinIdDESC(myCategory);     // 먼저 카테고리로 구분
+                        }
+                        return MyCategoryResponse.builder()
+                                .myCategoryId(myCategory.getMyCategoryId())
+                                .myCategoryName(myCategory.getMyCategoryName())
+                                .myCategoryScript(myCategory.getMyCategoryScript())
+                                .myCategoryIcon(myCategory.getMyCategoryIcon())
+                                .userPublishCategory(finalUser.getPublishCategory())        // user의 publishCategory는 본인만 볼 수 있게
+                                .publishCategory(myCategory.getPublishCategory())
+                                .pinCnt(pinList.size())
+                                .build();
+                    })
+                    .collect(Collectors.toList());
+
+            return PagingResponse.builder()
+                    .hasNext(myCategoryList.hasNext())
+                    .result(result)
+                    .build();
+
         }
-        User finalUser = user;
-
-
-        List<MyCategoryResponse> result = myCategoryList.stream()
-                .map(myCategory -> {
-                    List<Pin> pinList;
-                    if (townName != null) {
-                        pinList = pinRepository.findPinsByMyCategoryAndTownNameAndPinIdDESC(myCategory, townName);     // 먼저 카테고리로 구분
-                    } else {
-                        pinList = pinRepository.findPinsByMyCategoryAndPinIdDESC(myCategory);     // 먼저 카테고리로 구분
-                    }
-                    return MyCategoryResponse.builder()
-                            .myCategoryId(myCategory.getMyCategoryId())
-                            .myCategoryName(myCategory.getMyCategoryName())
-                            .myCategoryScript(myCategory.getMyCategoryScript())
-                            .myCategoryIcon(myCategory.getMyCategoryIcon())
-                            .publishCategory(finalUser.getPublishCategory())
-                            .pinCnt(pinList.size())            // pin 개수 받아오기로 변경
-                            .build();
-                })
-                .collect(Collectors.toList());
-
-        return PagingResponse.builder()
-                .hasNext(myCategoryList.hasNext())
-                .result(result)
-                .build();
-
     }
 
     @Transactional(readOnly = true)
@@ -103,7 +128,7 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                 }
             user = userRepository.findByNickname(nickname)
                     .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
-            myCategory = myCategoryRepository.findByMyCategoryPublicIdAndUserNickname(nickname, myCategoryId);
+            myCategory = myCategoryRepository.findByMyCategoryPublicIdAndUserNickname(nickname, myCategoryId);          // PUBLIC 값에 따라 보이는 CATEGORY 처리, PIN에서까지 하지않아도 됨
         } else {
             myCategory = myCategoryRepository.findByMyCategoryIdAndUserNickname(user.getNickname(), myCategoryId);
         }
@@ -185,6 +210,25 @@ public class MyCategoryServiceImpl implements MyCategoryService {
     }
 
     @Transactional
+    public void setUserPublishCategory(User user, PublishStatus publishCategory) {
+        user.updatePublishCategory(publishCategory);
+        userRepository.save(user);
+        List<MyCategory> myCategoryList = myCategoryRepository.findByUser(user);
+
+        if (publishCategory == PublishStatus.PUBLIC) {
+            for (MyCategory myCategory: myCategoryList) {
+                myCategory.updatePublishCategory(PublishStatus.PUBLIC);
+            }
+            myCategoryRepository.saveAll(myCategoryList);
+        } else {
+            for (MyCategory myCategory: myCategoryList) {
+                myCategory.updatePublishCategory(myCategory.getPreviousPublishCategory());
+            }
+            myCategoryRepository.saveAll(myCategoryList);
+        }
+    }
+
+    @Transactional
     public void createMyCategory(User user, CreateMyCategoryRequest createMyCategory) {
         // 중복 이름 체크
         myCategoryRepository.findByMyCategoryNameAndUser(createMyCategory.getMyCategoryName(), user)
@@ -197,6 +241,7 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                 .myCategoryName(createMyCategory.getMyCategoryName())
                 .myCategoryIcon(createMyCategory.getMyCategoryIcon())
                 .myCategoryScript(createMyCategory.getMyCategoryScript())
+                .publishCategory(createMyCategory.getPublishCategory())
                 .user(user)
                 .build();
 
@@ -227,6 +272,10 @@ public class MyCategoryServiceImpl implements MyCategoryService {
 
         if (updateMyCategory.getMyCategoryScript() != null) {
             existingMyCategory.updateMyCategoryScript(updateMyCategory.getMyCategoryScript());
+        }
+
+        if (updateMyCategory.getPublishCategory() != null) {
+            existingMyCategory.updatePublishCategory(updateMyCategory.getPublishCategory());
         }
 
         myCategoryRepository.save(existingMyCategory);

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -210,7 +210,7 @@ public class MyCategoryServiceImpl implements MyCategoryService {
     }
 
     @Transactional
-    public void setUserPublishCategory(User user, PublishStatus publishCategory) {
+    public void savePublishCategory(User user, PublishStatus publishCategory) {
         user.updatePublishCategory(publishCategory);
         userRepository.save(user);
         List<MyCategory> myCategoryList = myCategoryRepository.findByUser(user);
@@ -274,7 +274,7 @@ public class MyCategoryServiceImpl implements MyCategoryService {
             existingMyCategory.updateMyCategoryScript(updateMyCategory.getMyCategoryScript());
         }
 
-        if (updateMyCategory.getPublishCategory() != null) {
+        if (updateMyCategory.getPublishCategory() != null && user.getPublishCategory().equals(PublishStatus.PUBLIC)) {          // USER의 publishCategory가 PUBLIC이여야만 변경 가능
             existingMyCategory.updatePublishCategory(updateMyCategory.getPublishCategory());
         }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
@@ -103,7 +103,7 @@ public class User extends BaseTime {
         this.publishReview = status;
     }
 
-    public void updatePublishPin(PublishStatus status) {
+    public void updatePublishCategory(PublishStatus status) {
         this.publishCategory = status;
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/request/PublishingInfoRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/request/PublishingInfoRequest.java
@@ -2,15 +2,15 @@ package com.umc.gusto.domain.user.model.request;
 
 public class PublishingInfoRequest {
     private boolean publishReview;
-    private boolean publishPin;
+    private boolean publishCategory;
     private boolean publishRoute;
 
     public boolean getPublishReview() {
         return this.publishReview;
     }
 
-    public boolean getPublishPin() {
-        return this.publishPin;
+    public boolean getPublishCategory() {
+        return this.publishCategory;
     }
 
     public boolean getPublishRoute() { return this.publishRoute; }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.umc.gusto.domain.user.service;
 
+import com.umc.gusto.domain.myCategory.repository.MyCategoryRepository;
+import com.umc.gusto.domain.myCategory.service.MyCategoryService;
 import com.umc.gusto.domain.user.entity.Follow;
 import com.umc.gusto.domain.user.entity.Social;
 import com.umc.gusto.domain.user.entity.User;
@@ -45,6 +47,7 @@ public class UserServiceImpl implements UserService{
     private final RedisService redisService;
     private final FollowRepository followRepository;
     private final S3Service s3Service;
+    private final MyCategoryService myCategoryService;
 
     private static final long NICKNAME_EXPIRED_TIME = 1000L * 60 * 15;
     private static final int MAX_NICKNAME_NUMBER = 999;
@@ -258,14 +261,17 @@ public class UserServiceImpl implements UserService{
     @Override
     public void updatePublishingInfo(User user, PublishingInfoRequest request) {
         PublishStatus reviewStatus = (request.getPublishReview()) ?PublishStatus.PUBLIC : PublishStatus.PRIVATE;
-        PublishStatus pinStatus = (request.getPublishPin()) ? PublishStatus.PUBLIC : PublishStatus.PRIVATE;
+        PublishStatus categoryStatus = (request.getPublishCategory()) ? PublishStatus.PUBLIC : PublishStatus.PRIVATE;
         PublishStatus routeStatus = (request.getPublishRoute()) ? PublishStatus.PUBLIC : PublishStatus.PRIVATE;
 
         user.updatePublishReview(reviewStatus);
-        user.updatePublishCategory(pinStatus);
+        user.updatePublishCategory(categoryStatus);
         user.updatePublishRoute(routeStatus);
 
         userRepository.save(user);
+
+        PublishStatus newPublishCategory =  categoryStatus == PublishStatus.PUBLIC? PublishStatus.PUBLIC : PublishStatus.PRIVATE;
+        myCategoryService.savePublishCategory(user, newPublishCategory);
     }
 
     @Override

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -262,7 +262,7 @@ public class UserServiceImpl implements UserService{
         PublishStatus routeStatus = (request.getPublishRoute()) ? PublishStatus.PUBLIC : PublishStatus.PRIVATE;
 
         user.updatePublishReview(reviewStatus);
-        user.updatePublishPin(pinStatus);
+        user.updatePublishCategory(pinStatus);
         user.updatePublishRoute(routeStatus);
 
         userRepository.save(user);

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -14,6 +14,7 @@ public enum Code {
     //User 관련 에러 +0
     USER_FOLLOW_SELF(HttpStatus.FORBIDDEN, 403001, "자신을 팔로우할 수 없습니다."),
     USER_NOT_FOUND_SELF(HttpStatus.FORBIDDEN, 403002, "자신의 닉네임을 사용해 접근할 수 없습니다."),
+    USER_PUBLISH_CATEGORY_PRIVATE(HttpStatus.FORBIDDEN, 403003, "마이페이지의 publishCategory가 PRIVATE 상태입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404001, "존재하지 않는 유저입니다."),
     USER_FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, 404002, "팔로우한 유저가 아닙니다."),
     USER_FOLLOW_NO_MORE_CONTENT(HttpStatus.NOT_FOUND, 404003, "리스트가 더이상 존재하지 않습니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 내 카테고리 개별/전체 공개 여부에 따른 수정 및 추가
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 각 카테고리의 공개여부 변경과 마이페이지 내에서 공개여부 변경 로직 추가
  - 마이페이지 공개 여부 on일 때만 각 카테고리 공개여부 변경 가능
  - 마이페이지 공개 여부 off일 때는 모든 카테고리 공개 여부가 off, on일 때의 공개 여부 값을 기억해 다시 on 상태가 되면 사용

### 작업 내역

- User의 publishCategory가 PUBLIC일 경우에만 MyCategory의 publishCategory를 수정
- User의 publishCategory가 PRIVATE이 되는 순간, MyCategory의 publishCategory 값이 previousPublishCategory에 저장
    - User의 publishCategory가 PUBLIC이 되면, MyCategory의 previousPublishCategory값을 가져와 publishCategory에서 사용
- 타인의 카테고리 조회 시 User의 publishCategory 조회 시 null 처리

### 작업 후 기대 동작(스크린샷)

- 타인의 카테고리 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/102590823/2c80e598-53f5-453d-80bd-45eb767c6bb8)
- 마이페이지 공개여부가 off(PRIVATE)일 때, 카테고리 수정
![스크린샷 2024-06-19 155936](https://github.com/gusto-umc/Gusto-Server/assets/102590823/22347f66-c7eb-4c1c-b780-c5c840ee7263)
- 마이페이지 공개 여부가 on(PUBLIC)일 때, 카테고리 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/102590823/7943c5fe-ced3-4a96-8982-c340e2048a64)
- 마이페이지 공개 여부가 off(PUBLIC)일 때, 카테고리 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/102590823/3c0686ea-cd19-4aab-b1be-95c1c804f5ae)
- 마이페이지 공개 여부가 다시 on(PUBLIC)일 때, 카테고리 조회(이전 on 일때 상태 기억)
![image](https://github.com/gusto-umc/Gusto-Server/assets/102590823/51cbee24-3bbf-4dc1-aa67-715fbb96c46d)
